### PR TITLE
Add no-arg constructor which is required when called from other libra…

### DIFF
--- a/src/disk91_LoRaE5.cpp
+++ b/src/disk91_LoRaE5.cpp
@@ -265,6 +265,14 @@ Disk91_LoRaE5::Disk91_LoRaE5(
     this->estimatedDCMs = 0;
 }
 
+Disk91_LoRaE5::Disk91_LoRaE5(
+) {
+    this->debugUart = NULL;
+    this->runningCommand = false;
+    this->atTimeout = __DSKLORAE5_DEFAULT_AT_TMOUT;
+    this->currentZone = DSKLORAE5_ZONE_UNDEFINED;
+    this->estimatedDCMs = 0;
+}
 
 Disk91_LoRaE5::~Disk91_LoRaE5(){
       this->end();              

--- a/src/disk91_LoRaE5.h
+++ b/src/disk91_LoRaE5.h
@@ -176,8 +176,11 @@ protected:
     );
 
 public:
+    Disk91_LoRaE5(                      // Required for use from other libraries - no-arg is called due to
+    );                                  //  #include "disk91_LoRaE5.h" before instantiation of calling class
+
     Disk91_LoRaE5(
-        bool       nothing = false       // if anyone can explain me why w/o param the constructer generate compilation error ?!?
+        bool       nothing             // if anyone can explain me why w/o param the constructer generate compilation error ?!?
     );
 
     Disk91_LoRaE5(
@@ -186,7 +189,7 @@ public:
     );
 
     Disk91_LoRaE5(
-        Serial_  * logSerial = NULL      // When set, the library debug is enabled               
+        Serial_  * logSerial             // When set, the library debug is enabled
     );
 
     ~Disk91_LoRaE5();


### PR DESCRIPTION
…ries in C++.  The include statement itself requires the no-arg.  Also, fixed a couple of defaulting clauses that made the two single-arg constructors essentially the same from an Arduino point of view.